### PR TITLE
Add Geo Web Clay Testnet Node

### DIFF
--- a/testnet-clay.json
+++ b/testnet-clay.json
@@ -3,5 +3,5 @@
   "/dns4/ipfs-clay.ceramic.network/tcp/4012/wss/p2p/QmSqeKpCYW89XrHHxtEQEWXmznp6o336jzwvdodbrGeLTk",
   "/dns4/ipfs-clay-internal.3boxlabs.com/tcp/4012/wss/p2p/QmQotCKxiMWt935TyCBFTN23jaivxwrZ3uD58wNxeg5npi",
   "/dns4/ipfs-clay-cas.3boxlabs.com/tcp/4012/wss/p2p/QmbeBTzSccH8xYottaYeyVX8QsKyox1ExfRx7T1iBqRyCd",
-  "/dns4/ipfs-clay-1.ceramic.geoweb.network/tcp/4011/ws/p2p/QmbDGaByZoomn3NQQjZzwaPWH6ei3ptzWK7a7ECtS35DKL"
+  "/dns4/ipfs-clay-1.ceramic.geoweb.network/tcp/4012/ws/p2p/QmbDGaByZoomn3NQQjZzwaPWH6ei3ptzWK7a7ECtS35DKL"
 ]

--- a/testnet-clay.json
+++ b/testnet-clay.json
@@ -2,5 +2,6 @@
   "/dns4/ipfs-clay.3boxlabs.com/tcp/4012/wss/p2p/QmWiY3CbNawZjWnHXx3p3DXsg21pZYTj4CRY1iwMkhP8r3",
   "/dns4/ipfs-clay.ceramic.network/tcp/4012/wss/p2p/QmSqeKpCYW89XrHHxtEQEWXmznp6o336jzwvdodbrGeLTk",
   "/dns4/ipfs-clay-internal.3boxlabs.com/tcp/4012/wss/p2p/QmQotCKxiMWt935TyCBFTN23jaivxwrZ3uD58wNxeg5npi",
-  "/dns4/ipfs-clay-cas.3boxlabs.com/tcp/4012/wss/p2p/QmbeBTzSccH8xYottaYeyVX8QsKyox1ExfRx7T1iBqRyCd"
+  "/dns4/ipfs-clay-cas.3boxlabs.com/tcp/4012/wss/p2p/QmbeBTzSccH8xYottaYeyVX8QsKyox1ExfRx7T1iBqRyCd",
+  "/dns4/ipfs-clay-1.ceramic.geoweb.network/tcp/4011/ws/p2p/QmbDGaByZoomn3NQQjZzwaPWH6ei3ptzWK7a7ECtS35DKL"
 ]


### PR DESCRIPTION
We are running a Clay testnet node as part of the [Geo Web](https://geoweb.network) and would like to add it to the peerlist for others to discover.

This node is also the default HTTP API that our [Cadastre App](https://geoweb.eth.link) connects to.