### PR TITLE
Finish automated test in CI

### DIFF
--- a/.github/workflows/test_ipfs_connection.yml
+++ b/.github/workflows/test_ipfs_connection.yml
@@ -14,9 +14,10 @@ on:
         required: true
         default: 'dev-unstable'
 
+# TODO: Make this smarter so it only runs for environment that actually gets updated
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/test_ipfs_connection.yml
+++ b/.github/workflows/test_ipfs_connection.yml
@@ -3,10 +3,10 @@ name: Test IPFS connection
 on:
   push:
     branches:
-      - ci/testing
-  # pull_request:
-  #   branches:
-  #     - main
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/test_ipfs_connection.yml
+++ b/.github/workflows/test_ipfs_connection.yml
@@ -23,8 +23,10 @@ jobs:
     env:
       JEST_CERAMIC_NETWORK: ${{ matrix.env }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
 
       - name: Run test
         run: |

--- a/.github/workflows/test_ipfs_connection.yml
+++ b/.github/workflows/test_ipfs_connection.yml
@@ -1,6 +1,9 @@
 name: Test IPFS connection
 
 on:
+  push:
+    branches:
+      - ci/testing
   # pull_request:
   #   branches:
   #     - main

--- a/.github/workflows/test_ipfs_connection.yml
+++ b/.github/workflows/test_ipfs_connection.yml
@@ -31,4 +31,5 @@ jobs:
       - name: Run test
         run: |
             cd ./test
+            npm ci
             npm run test

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -18,15 +18,11 @@ const peerlistByNetwork: Record<string, string[]> = {
 const tempFilePath = () => `/tmp/jest/peerlist/connect.test.ts/${Date.now()}`
 
 describe('IpfsDaemon', () => {
-    let ipfsDaemon;
-    afterEach(async () => {
-        await ipfsDaemon.stop()
-    })
     test('fails to connect to invalid bootstrap list', async () => {
         const consoleSpy = jest.spyOn(console, 'log')
 
         const peerlist = ['not.a.multiaddress']
-        ipfsDaemon = await createIpfsDaemon(peerlist)
+        const ipfsDaemon = await createIpfsDaemon(peerlist)
         await ipfsDaemon.start()
 
         for (const multiaddress of peerlist) {
@@ -36,12 +32,13 @@ describe('IpfsDaemon', () => {
             })
             expect(result).toBeTruthy()
         }
+        await ipfsDaemon.stop()
     })
     test('connects successfully to valid bootstrap list', async () => {
         const consoleSpy = jest.spyOn(console, 'log')
 
         const peerlist = peerlistByNetwork[ceramicNetwork]
-        ipfsDaemon = await createIpfsDaemon(peerlist)
+        const ipfsDaemon = await createIpfsDaemon(peerlist)
         await ipfsDaemon.start()
 
         for (const multiaddress of peerlist) {
@@ -51,6 +48,7 @@ describe('IpfsDaemon', () => {
             })
             expect(result).toBeTruthy()
         }
+        await ipfsDaemon.stop()
     })
 })
 

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -19,6 +19,7 @@ const tempFilePath = () => `/tmp/jest/peerlist/connect.test.ts/${Date.now()}`
 
 describe('IpfsDaemon', () => {
     test('fails to connect to invalid bootstrap list', async () => {
+        jest.setTimeout(5000 * 60) // 5m
         const consoleSpy = jest.spyOn(console, 'log')
 
         const peerlist = ['not.a.multiaddress']
@@ -35,6 +36,7 @@ describe('IpfsDaemon', () => {
         await ipfsDaemon.stop()
     })
     test('connects successfully to valid bootstrap list', async () => {
+        jest.setTimeout(5000 * 60) // 5m
         const consoleSpy = jest.spyOn(console, 'log')
 
         const peerlist = peerlistByNetwork[ceramicNetwork]


### PR DESCRIPTION
### Motivation

Ensure we can test peerlist connection on push or pr

### Changes

Two changes were required to prevent test failures due to not connecting:
- Removed ipfs variable sharing from tests
- Increased jest timeout

CI cleanups
- Added node
- Workflow gets triggered on push or pr
- Uses ubuntu 18 with GH runner instead of self hosted

### Future work
Make the workflow smarter so we only run the tests for a specific file change