### PR TITLE
chore: add fungyproof to clay peers list

### DIFF
--- a/testnet-clay.json
+++ b/testnet-clay.json
@@ -3,5 +3,6 @@
   "/dns4/ipfs-ceramic-public-clay-external.ceramic.network/tcp/4012/wss/p2p/QmSqeKpCYW89XrHHxtEQEWXmznp6o336jzwvdodbrGeLTk",
   "/dns4/ipfs-ceramic-private-clay-external.3boxlabs.com/tcp/4012/wss/p2p/QmQotCKxiMWt935TyCBFTN23jaivxwrZ3uD58wNxeg5npi",
   "/dns4/ipfs-cas-clay-external.3boxlabs.com/tcp/4012/wss/p2p/QmbeBTzSccH8xYottaYeyVX8QsKyox1ExfRx7T1iBqRyCd",
-  "/dns4/ipfs-clay-1.ceramic.geoweb.network/tcp/4012/ws/p2p/QmbDGaByZoomn3NQQjZzwaPWH6ei3ptzWK7a7ECtS35DKL"
+  "/dns4/ipfs-clay-1.ceramic.geoweb.network/tcp/4012/ws/p2p/QmbDGaByZoomn3NQQjZzwaPWH6ei3ptzWK7a7ECtS35DKL",
+  "/dns4/ipfs-external.fungy.link/tcp/4012/wss/p2p/QmRJsyC2Qmdgu3PGshFoSPe9jGgghVbFnapqXkCM8DpUR4"
 ]


### PR DESCRIPTION
### Team
FungyProof

### Use case
We are building FungyProof an NFT grading and enrichments platform inspired by traditional Third-party Grading Services. We use Ceramic to store cross-chain NFT grades and Enrichments in a public registry and to give owners a mechanism to create public profiles for their NFTs which are owned by the NFT itself.

### Overview
Our Node infrastructure is run on AWS ECS (fargate). The service is run behind a Network Load Balancer and uses TLS termination at the Load Balancer level in conjunction with Cloudfront to enable path based routing to the Ceramic API.
We automate deploying this infrastructure using Pulumi. We plan to cleanup and opensource this Pulumi component as soon as we can to make this process simpler for others attempting to do the same thing.

We plan to stay on clay for the next week, then migrate to mainnet once we are stable. We do not plan to host both a clay and mainnet cluster in parallel due to costs.

Here is our internal routing setup:
* `https://ceramic-external.fungy.link/` --> `ipfs-ceramic-container:7007` 
* `https://ipfs-external.fungy.link` --> `ipfs-ceramic-container:4012` (with TLS termination at the LB)

In addition we created a custom gateway to create a shorter link to streamID contents:
* `https://fungy.link/{streamID}` --> `ipfs-ceramic-container:7007/api/v0/streams/{streamID}/content`

**Multiaddress persistence:**

We are using a `.ipfs` and `.ceramic` folder persisted to S3 for our persistence with a lifecycle rule to backup the data to glacier. We also have manually backed up our multiaddress / keys to an internal redundant backup drive.

**Ceramic State Store / IPFS Repo persistence:**
In addition to the above, we are in the process of building out a replication job which will store the ipfs/ceramic state (minus our private keys) in Arweave.

**Static IP:**
We are on a cluster with multiple subnets so our requests will come from one of two IPs. If it needs to be a single one we can also drop to a single subnet.

* 44.196.239.180
* 54.221.229.208
