### PR TITLE
add MuseX node to mainnet

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -5,5 +5,6 @@
   "/dns4/ipfs-ceramic-elp-1-1-external.3boxlabs.com/tcp/4012/wss/p2p/QmUiF8Au7wjhAF9BYYMNQRW5KhY7o8fq4RUozzkWvHXQrZ",
   "/dns4/ipfs-ceramic-elp-1-2-external.3boxlabs.com/tcp/4012/wss/p2p/QmRNw9ZimjSwujzS3euqSYxDW9EHDU5LB3NbLQ5vJ13hwJ",
   "/dns4/ceramic-node.vitalpointai.com/tcp/4012/ws/p2p/QmVH335h3srKvSTZKr5bcLFbnvfVZSewVzpkbEX9XHcLsQ",
-  "/dns4/ipfs-ceramic-elp-external.ownershiplabs.com/tcp/4012/ws/p2p/QmSiSc4WetTWsNzv8ukpXk57tyDNVqwbvMAKp1MUvo5pF8"
+  "/dns4/ipfs-ceramic-elp-external.ownershiplabs.com/tcp/4012/ws/p2p/QmSiSc4WetTWsNzv8ukpXk57tyDNVqwbvMAKp1MUvo5pF8",
+  "/dns4/ceramic-node.musex.io/tcp/4012/ws/p2p/QmVWJymQvxWfTcd26dcc2YDpHtA2AJ7tSpzjR2YZR2QEsD"
 ]


### PR DESCRIPTION
### Team
MuseX (DAOSquare)

*Multiaddress persistence:*
/dns4/ceramic-node.musex.io/tcp/4012/ws/p2p/QmVWJymQvxWfTcd26dcc2YDpHtA2AJ7tSpzjR2YZR2QEsD

*Ceramic State Store persistence:*
upload data to Google Drive and pinata everyday

*IPFS Repo persistence:*
same with state store persistence.

*Static IP:*
47.241.24.129
