### PR TITLE
Add mainnet peer from hoprnet

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -7,4 +7,5 @@
   "/dns4/ceramic-node.vitalpointai.com/tcp/4012/ws/p2p/QmVH335h3srKvSTZKr5bcLFbnvfVZSewVzpkbEX9XHcLsQ",
   "/dns4/ipfs-ceramic-elp-external.ownershiplabs.com/tcp/4012/ws/p2p/QmSiSc4WetTWsNzv8ukpXk57tyDNVqwbvMAKp1MUvo5pF8",
   "/dns4/ceramic-node.musex.io/tcp/4012/ws/p2p/QmVWJymQvxWfTcd26dcc2YDpHtA2AJ7tSpzjR2YZR2QEsD"
+  "/dns4/ceramic-one.hoprnet.io/tcp/4012/wss/p2p/QmRVm5wdoQBym4yY15t5TNb6uVNLyEBxB2MNoUL4Mfq5pq"
 ]


### PR DESCRIPTION
### Team
<!--Team name or your github handle if you are a team of one-->
https://github.com/hoprnet
### Use case
<!--A few words about what how your node will be used so we can make recommendations for your setup-->
It will be used for debug log collection from hoprd peer nodes as well as hoprd testnet analytics. 
### Overview
<!--How are you running your nodes? What cloud infrastructure? Are you running IPFS out-of-process?-->
Run on a GCP VM using Docker containers. IPFS is run out-of-process. 

*Multiaddress persistence:*
<!--What are you doing to ensure your multiaddress won't change?-->

We've made backups of the configuration. Moreover, the configuration is persisted across container and system reboots. 

*Ceramic State Store persistence:*
<!--What are you doing to ensure your Ceramic data doesn't get lost?-->

We've made backups of the configuration and will continue doing so. Moreover, the state data is persisted across container and system reboots.

*IPFS Repo persistence:*

<!--What are you doing to ensure your IPFS data doesn't get lost?-->
The repo data is persisted across container and system reboots.

*Static IP:*

<!--Static IP address of the machine your Ceramic daemon runs on.-->
34.65.245.112