### PR TITLE
Yam Ceramic Node

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -6,5 +6,6 @@
   "/dns4/ipfs-ceramic-elp-1-2-external.3boxlabs.com/tcp/4012/wss/p2p/QmRNw9ZimjSwujzS3euqSYxDW9EHDU5LB3NbLQ5vJ13hwJ",
   "/dns4/ceramic-node.vitalpointai.com/tcp/4012/ws/p2p/QmVH335h3srKvSTZKr5bcLFbnvfVZSewVzpkbEX9XHcLsQ",
   "/dns4/ipfs-ceramic-elp-external.ownershiplabs.com/tcp/4012/ws/p2p/QmSiSc4WetTWsNzv8ukpXk57tyDNVqwbvMAKp1MUvo5pF8",
-  "/dns4/ceramic-node.musex.io/tcp/4012/ws/p2p/QmVWJymQvxWfTcd26dcc2YDpHtA2AJ7tSpzjR2YZR2QEsD"
+  "/dns4/ceramic-node.musex.io/tcp/4012/ws/p2p/QmVWJymQvxWfTcd26dcc2YDpHtA2AJ7tSpzjR2YZR2QEsD",
+  "/dns4/ipfs-ceramic-elp.yam.finance/tcp/4012/ws/p2p/QmSiSc4WetTWsNzv8ukpXk57tyDNVqwbvMAKp1MUvo5pF8"
 ]


### PR DESCRIPTION

### Team:
**Yam**

### Use case:
We are building a marketplace dApp for NFTs at Yam, where we will be using ceramic idx for users profiles, as well planning for other uses on yam projects to come in the future.

### Overview:
Running the ceramic daemon and ipfs daemon out-of-process.

*Multiaddress persistence:*
- multiaddress `/dns4/ipfs-ceramic-elp.yam.finance/tcp/4012/ws/p2p/QmSiSc4WetTWsNzv8ukpXk57tyDNVqwbvMAKp1MUvo5pF8`
- static domain `34.88.123.94` `ipfs-ceramic-elp.yam.finance`

*Ceramic State Store persistence:*
We do backups everyday.

*IPFS Repo persistence:*
We do backups everyday.

*Static IP:*
- `34.88.123.94:7007`