### PR TITLE
add HiÐΞ node to mainnet

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -8,5 +8,6 @@
   "/dns4/ipfs-ceramic-elp-external.ownershiplabs.com/tcp/4012/ws/p2p/QmSiSc4WetTWsNzv8ukpXk57tyDNVqwbvMAKp1MUvo5pF8",
   "/dns4/ceramic-node.musex.io/tcp/4012/ws/p2p/QmVWJymQvxWfTcd26dcc2YDpHtA2AJ7tSpzjR2YZR2QEsD",
   "/dns4/ipfs-ceramic-elp.yam.finance/tcp/4012/ws/p2p/QmSiSc4WetTWsNzv8ukpXk57tyDNVqwbvMAKp1MUvo5pF8",
-  "/dns4/ceramic-one.hoprnet.io/tcp/4012/wss/p2p/QmRVm5wdoQBym4yY15t5TNb6uVNLyEBxB2MNoUL4Mfq5pq"
+  "/dns4/ceramic-one.hoprnet.io/tcp/4012/wss/p2p/QmRVm5wdoQBym4yY15t5TNb6uVNLyEBxB2MNoUL4Mfq5pq",
+  "/dns4/ceramic.hide.ac/tcp/4012/wss/p2p/Qmc3krvy6CFgCn8bBCooSrAcTC64Vc8i7cAc84iSUpKVkT"
 ]


### PR DESCRIPTION
### Team
<!--Team name or your github handle if you are a team of one-->
[Warashibe Inc.](https://docs.hide.ac/#team) ([github](https://github.com/warashibe))

### Use case
<!--A few words about what how your node will be used so we can make recommendations for your setup-->
[HiÐΞ](https://hide.ac) is an offline-first decentralized CMS / blogging platform, where writers can upload articles to the Ceramic network and tokenize them as NFTs to get rewards from L2-based DAO protocol (HiÐΞ Protocol).

### Overview
<!--How are you running your nodes? What cloud infrastructure? Are you running IPFS out-of-process?-->
We are running our node using the Docker containers on GCP Compute Engine with out-of-process IPFS.

*Multiaddress persistence:*
<!--What are you doing to ensure your multiaddress won't change?-->
We have made a backup of the config file and also saving the config file on a separate disk mounted to the instance.

*Ceramic State Store persistence:*
<!--What are you doing to ensure your Ceramic data doesn't get lost?-->
We are saving the Ceramic data on a separate disk mounted to the instance so it won't be lost in case of crashes and reboots.

*IPFS Repo persistence:*
<!--What are you doing to ensure your IPFS data doesn't get lost?-->
Likewise, we are saving the IPFS data on a separate disk mounted to the instance so it won't be lost in case of crashes and reboots.

*Static IP:*
<!--Static IP address of the machine your Ceramic daemon runs on.-->
34.146.78.211
