### PR TITLE
DDshare Ceramic Node

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -10,5 +10,6 @@
   "/dns4/ipfs-ceramic-elp.yam.finance/tcp/4012/ws/p2p/QmSiSc4WetTWsNzv8ukpXk57tyDNVqwbvMAKp1MUvo5pF8",
   "/dns4/ceramic-one.hoprnet.io/tcp/4012/wss/p2p/QmRVm5wdoQBym4yY15t5TNb6uVNLyEBxB2MNoUL4Mfq5pq",
   "/dns4/ceramic.hide.ac/tcp/4012/wss/p2p/Qmc3krvy6CFgCn8bBCooSrAcTC64Vc8i7cAc84iSUpKVkT",
-  "/dns4/ipfs-external.fungy.link/tcp/4012/wss/p2p/QmRJsyC2Qmdgu3PGshFoSPe9jGgghVbFnapqXkCM8DpUR4"
+  "/dns4/ipfs-external.fungy.link/tcp/4012/wss/p2p/QmRJsyC2Qmdgu3PGshFoSPe9jGgghVbFnapqXkCM8DpUR4",
+  "/dns4/anipfs.space/tcp/4012/ws/p2p/QmPgD1CwHHijFrAdWfCptrDQ2dLcxSFsAMTQ1JALqmwCu1"
 ]

--- a/mainnet.json
+++ b/mainnet.json
@@ -11,5 +11,5 @@
   "/dns4/ceramic-one.hoprnet.io/tcp/4012/wss/p2p/QmRVm5wdoQBym4yY15t5TNb6uVNLyEBxB2MNoUL4Mfq5pq",
   "/dns4/ceramic.hide.ac/tcp/4012/wss/p2p/Qmc3krvy6CFgCn8bBCooSrAcTC64Vc8i7cAc84iSUpKVkT",
   "/dns4/ipfs-external.fungy.link/tcp/4012/wss/p2p/QmRJsyC2Qmdgu3PGshFoSPe9jGgghVbFnapqXkCM8DpUR4",
-  "/dns4/anipfs.space/tcp/4012/p2p/QmPgD1CwHHijFrAdWfCptrDQ2dLcxSFsAMTQ1JALqmwCu1"
+  "/dns4/anipfs.space/tcp/4012/ws/p2p/QmPgD1CwHHijFrAdWfCptrDQ2dLcxSFsAMTQ1JALqmwCu1"
 ]

--- a/mainnet.json
+++ b/mainnet.json
@@ -11,5 +11,5 @@
   "/dns4/ceramic-one.hoprnet.io/tcp/4012/wss/p2p/QmRVm5wdoQBym4yY15t5TNb6uVNLyEBxB2MNoUL4Mfq5pq",
   "/dns4/ceramic.hide.ac/tcp/4012/wss/p2p/Qmc3krvy6CFgCn8bBCooSrAcTC64Vc8i7cAc84iSUpKVkT",
   "/dns4/ipfs-external.fungy.link/tcp/4012/wss/p2p/QmRJsyC2Qmdgu3PGshFoSPe9jGgghVbFnapqXkCM8DpUR4",
-  "/dns4/anipfs.space/tcp/4012/ws/p2p/QmPgD1CwHHijFrAdWfCptrDQ2dLcxSFsAMTQ1JALqmwCu1"
+  "/dns4/anipfs.space/tcp/4012/wss/p2p/QmPgD1CwHHijFrAdWfCptrDQ2dLcxSFsAMTQ1JALqmwCu1"
 ]

--- a/mainnet.json
+++ b/mainnet.json
@@ -11,5 +11,5 @@
   "/dns4/ceramic-one.hoprnet.io/tcp/4012/wss/p2p/QmRVm5wdoQBym4yY15t5TNb6uVNLyEBxB2MNoUL4Mfq5pq",
   "/dns4/ceramic.hide.ac/tcp/4012/wss/p2p/Qmc3krvy6CFgCn8bBCooSrAcTC64Vc8i7cAc84iSUpKVkT",
   "/dns4/ipfs-external.fungy.link/tcp/4012/wss/p2p/QmRJsyC2Qmdgu3PGshFoSPe9jGgghVbFnapqXkCM8DpUR4",
-  "/dns4/anipfs.space/tcp/4012/wss/p2p/QmPgD1CwHHijFrAdWfCptrDQ2dLcxSFsAMTQ1JALqmwCu1"
+  "/dns4/anipfs.space/tcp/4012/p2p/QmPgD1CwHHijFrAdWfCptrDQ2dLcxSFsAMTQ1JALqmwCu1"
 ]


### PR DESCRIPTION
### Team
DDshare

### Use case
We are building decentralized Data Sharing Infrastructure , Based on IPFS & FileCoin ,Designed to store and share humanity's data!

### Overview
Running the ceramic daemon !
Use ceramic and idx to store user data 

*Multiaddress persistence:*
multiaddress /dns4/anipfs.space/tcp/4012/ws/p2p/QmPgD1CwHHijFrAdWfCptrDQ2dLcxSFsAMTQ1JALqmwCu1
static domain  `anipfs.space`

*Ceramic State Store persistence:*
We do backups everyday.
We check it everyday.


*IPFS Repo persistence:*
We do backups everyday.
We check it everyday.

*Static IP:*
`45.63.127.179`