### PR TITLE
add Safient Ceramic mainnet node

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -11,5 +11,6 @@
   "/dns4/ceramic-one.hoprnet.io/tcp/4012/wss/p2p/QmRVm5wdoQBym4yY15t5TNb6uVNLyEBxB2MNoUL4Mfq5pq",
   "/dns4/ceramic.hide.ac/tcp/4012/wss/p2p/Qmc3krvy6CFgCn8bBCooSrAcTC64Vc8i7cAc84iSUpKVkT",
   "/dns4/ipfs-external.fungy.link/tcp/4012/wss/p2p/QmRJsyC2Qmdgu3PGshFoSPe9jGgghVbFnapqXkCM8DpUR4",
-  "/dns4/anipfs.space/tcp/4012/ws/p2p/QmPgD1CwHHijFrAdWfCptrDQ2dLcxSFsAMTQ1JALqmwCu1"
+  "/dns4/anipfs.space/tcp/4012/ws/p2p/QmPgD1CwHHijFrAdWfCptrDQ2dLcxSFsAMTQ1JALqmwCu1",
+  "/dns4/ceramic.safient.io/tcp/4012/ws/p2p/QmZ28QWFwVZWHmfgh7RdsCcMtFVQxetHaGmkpw2q8ACWh6"
 ]


### PR DESCRIPTION
### Team
[Safient](https://code.safient.io)

### Use case
[Safient](https://safient.io) is a trustless safe and inheritance protocol. Safient leverages the Ceramic network as an identity layer by storing user information. and links the safe information to make it immutable. Safient will generate a unique identity (DID) and maintain them on the Ceramic network to easily interact with each user on the network.

### Overview
We are running Ceramic and IPFS as separate processes (We have configured services) on an AWS  instance ( 4 CPUs and 16 GB RAM).

*Multiaddress persistence:*
The IPFS configs are backed up on a different volume and we use AWS elastic IP to persist the address.

*Ceramic State Store persistence:*
The ceramic state stores are backed up on a separate mounted volume.

*IPFS Repo persistence:*
The IPFS data is backed up on a separate mounted volume.

*Static IP:*
13.127.142.35
