### PR TITLE
Update TheCoin ipfs address

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -14,5 +14,5 @@
   "/dns4/anipfs.space/tcp/4012/ws/p2p/QmPv9nch9WDCixxfmmA5znsPExLKM78gwgc1nNnuu4rUTG",
   "/dns4/ipfs-ceramic-prd-1-1-external.cybertino.io/tcp/4012/wss/p2p/QmbW4WHPVgBaDz9H7nef3iZ7bx9ExWA2FbMGciK1f1wNcA",
   "/dns4/ceramic.safient.io/tcp/4012/ws/p2p/QmZ28QWFwVZWHmfgh7RdsCcMtFVQxetHaGmkpw2q8ACWh6",
-  "/dns4/ceramic-node.thecoin.io/tcp/4012/ws/p2p/QmP5BvekZy5AohYnQQTtEVT8BvnAeKk6QedY5P9MdTp5My"
+  "/dns4/tccc-ipfs-daemon.eastus.azurecontainer.io/tcp/4012/ws/p2p/QmP5BvekZy5AohYnQQTtEVT8BvnAeKk6QedY5P9MdTp5My"
 ]


### PR DESCRIPTION
It turns out Azure containers' public IP addresses are ephemeral, and cannot be relied on.

Fixed by assigning an azure-managed DNS entry which (I assume) will consistently point to our running container

Nothing about the running instances changes.