### PR TITLE
add(node): add Figment's node to mainnet peerlist

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -15,5 +15,6 @@
   "/dns4/ceramic.safient.io/tcp/4012/ws/p2p/QmZ28QWFwVZWHmfgh7RdsCcMtFVQxetHaGmkpw2q8ACWh6",
   "/dns4/tccc-ipfs-daemon.eastus.azurecontainer.io/tcp/4012/ws/p2p/QmP5BvekZy5AohYnQQTtEVT8BvnAeKk6QedY5P9MdTp5My",
   "/dns4/ipfs.ceramic.spruceid.xyz/tcp/4012/wss/p2p/QmafAQB9JMS59qNtiGNtmPP6PqXciehC9rwSQJ7dgCH1rU",
-  "/dns4/ceramic-prod-33-1-ipfs-nd-ex-1523272531.us-east-1.elb.amazonaws.com/tcp/4012/ws/p2p/QmWuMcMC3uq4aVDBehxYJy4ncaf1TdF5xmtq8WVZdAFtmN"
+  "/dns4/ceramic-prod-33-1-ipfs-nd-ex-1523272531.us-east-1.elb.amazonaws.com/tcp/4012/ws/p2p/QmWuMcMC3uq4aVDBehxYJy4ncaf1TdF5xmtq8WVZdAFtmN",
+  "/dns4/ceramic-node.figment.io/tcp/4012/ws/p2p/QmU7oXbft3fBXahQmoTiu3DaGmdRA2T3jQEUnDZ15NAAtJ"
 ]


### PR DESCRIPTION
### Team
Figment

*Submitter Discord handle:*
encoder#7777

### Use case
We need it for our Figment Learn campaign (learn.figment.io)

### Overview
We're running the Ceramic Node and IPFS (out of process) on our Kubernetes cluster with health checks that will automatically restart the pod and switch over the DNS record to the live pod. Both Ceramic and IPFS use S3 buckets for their keys/statestore.

*IPFS Multiaddress:*
`/ip4/ceramic-node.figment.io/tcp/4012/ws/p2p/QmU7oXbft3fBXahQmoTiu3DaGmdRA2T3jQEUnDZ15NAAtJ`

*IPFS Multiaddress persistence:*
We're using an S3 bucket in combination with NLB + Route 53 to automatically update our DNS entry whenever a pod gets restarted.

*Ceramic State Store persistence:*
See the above ^ - we're using an S3 bucket for the state store.

*IPFS Repo persistence:*
See the above ^ - we're using an S3 bucket for the state store.

*Static IPs*

Since we're running this on EKS, we have multiple IPs that need to be whitelisted:

`3.97.102.154`
`3.98.11.18`
`3.98.134.203`

