### PR TITLE
Add koios node to mainnet

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -14,5 +14,6 @@
   "/dns4/ipfs-ceramic-prd-1-1-external.cybertino.io/tcp/4012/wss/p2p/QmbW4WHPVgBaDz9H7nef3iZ7bx9ExWA2FbMGciK1f1wNcA",
   "/dns4/ceramic.safient.io/tcp/4012/ws/p2p/QmZ28QWFwVZWHmfgh7RdsCcMtFVQxetHaGmkpw2q8ACWh6",
   "/dns4/tccc-ipfs-daemon.eastus.azurecontainer.io/tcp/4012/ws/p2p/QmP5BvekZy5AohYnQQTtEVT8BvnAeKk6QedY5P9MdTp5My",
-  "/dns4/ipfs.ceramic.spruceid.xyz/tcp/4012/wss/p2p/QmafAQB9JMS59qNtiGNtmPP6PqXciehC9rwSQJ7dgCH1rU"
+  "/dns4/ipfs.ceramic.spruceid.xyz/tcp/4012/wss/p2p/QmafAQB9JMS59qNtiGNtmPP6PqXciehC9rwSQJ7dgCH1rU",
+  "/dns4/mgatsonides.nl/tcp/4012/wss/p2p/Qmbhej3gEsPq1Wuoh5ZizqDpi9neeeotSRS2FoAtjqDqM9"
 ]


### PR DESCRIPTION
### Team:
Koios
My discord handle is CryingEaglez#6584

### Use case:
We will use ceramic for our user (student/lecturer) profiles. We are planning to make use of the tileDocument streamtype for storing custom user data (stats for instance) so they can move between mobile and pc platforms and also exchange info with (and find) other users.

### Overview:
We are running our ceramic node on a locally hosted server. IPFS is ran out of process to have more control over the options, resource allocation, maintenance, debugging and observability.

*Multiaddress persistence:*
The multiaddress is stored locally and physically backed up.

*Ceramic State Store persistence:*
The ceramic state store and IPFS repo are stored locally and are hourly backed up to a NAS (with zfs)

*IPFS Repo persistence:*
The ceramic state store and IPFS repo are stored locally and are hourly backed up to a NAS (with zfs)

*Static IP:*
217.102.168.211