### PR TITLE
add MetaGame node to mainnet

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -16,5 +16,6 @@
   "/dns4/ceramic-ipfs.welibrary.io/tcp/4012/wss/p2p/QmYmQ487j4sXKu28hG7LVKtwXe8qTxbLsiZxtcjao2uwfn",
   "/dns4/ceramic-node.figment.io/tcp/4012/ws/p2p/QmU7oXbft3fBXahQmoTiu3DaGmdRA2T3jQEUnDZ15NAAtJ",
   "/dns4/mgatsonides.nl/tcp/4012/wss/p2p/Qmbhej3gEsPq1Wuoh5ZizqDpi9neeeotSRS2FoAtjqDqM9",
-  "/dns4/ipfs.rabbithole.gg/tcp/4012/wss/p2p/Qmc1e7SGtSFAAfzvD8nyGq9MvWebzsDCtgWD5ndJike4FZ"
+  "/dns4/ipfs.rabbithole.gg/tcp/4012/wss/p2p/Qmc1e7SGtSFAAfzvD8nyGq9MvWebzsDCtgWD5ndJike4FZ",
+  "/dns4/ipfs.metagame.wtf/tcp/4012/ws/p2p/QmVPNwwBtUC3fPTSSsVAgS1WMz1RbEzkDbDxU9BvatXWXZ"
 ]


### PR DESCRIPTION
### Team
[MetaGame](https://wiki.metagame.wtf) ([github](https://github.com/MetaFam))

*Submitter Discord handle:*
Polimyl#6848

### Use case
Our Ceramic node will be used for [MyMeta](https://my.metagame.wtf) to save our users' basicProfile, an extended profile set, skills description, and account verifications from IdentityLink.

### Overview
We are running both Ceramic and out-of-process IPFS Docker containers in a Google Kubernetes cluster (GKE Autopilot).

*IPFS Multiaddress:*
`/dns4/ipfs.metagame.wtf/tcp/4012/ws/p2p/QmVPNwwBtUC3fPTSSsVAgS1WMz1RbEzkDbDxU9BvatXWXZ`

*IPFS Multiaddress persistence:*
Each container mounts a persistent volume on it's data directory. These volumes also get snapshotted every 8 hours.

*Ceramic State Store persistence:*
See above

*IPFS Repo persistence:*
See above

*Static IP:*
35.245.132.221 (only for outbound traffic)

cc @dysbulic