### PR TITLE
Add bulla network to peerlist

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -19,5 +19,5 @@
   "/dns4/ipfs.rabbithole.gg/tcp/4012/wss/p2p/Qmc1e7SGtSFAAfzvD8nyGq9MvWebzsDCtgWD5ndJike4FZ",
   "/dns4/ipfs-ceramic-elp-external.ownershiplabs.com/tcp/4012/ws/p2p/QmQHTe4GoBmZ3GfZEfiFDWptFE7ij51QvYsuWGWi5kambc",
   "/dns4/ipfs.metagame.wtf/tcp/4012/ws/p2p/QmVPNwwBtUC3fPTSSsVAgS1WMz1RbEzkDbDxU9BvatXWXZ",
-  "/dns4/ipfs.bulla.network/tcp/4012/wss/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w"
+  "/dns4/ipfs.bulla.network/tcp/4012/wss/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w" 
 ]

--- a/mainnet.json
+++ b/mainnet.json
@@ -18,5 +18,6 @@
   "/dns4/mgatsonides.nl/tcp/4012/wss/p2p/Qmbhej3gEsPq1Wuoh5ZizqDpi9neeeotSRS2FoAtjqDqM9",
   "/dns4/ipfs.rabbithole.gg/tcp/4012/wss/p2p/Qmc1e7SGtSFAAfzvD8nyGq9MvWebzsDCtgWD5ndJike4FZ",
   "/dns4/ipfs-ceramic-elp-external.ownershiplabs.com/tcp/4012/ws/p2p/QmQHTe4GoBmZ3GfZEfiFDWptFE7ij51QvYsuWGWi5kambc",
-  "/dns4/ceramic.bulla.network/tcp/4012/wss/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w"
+  "/dns4/ipfs.metagame.wtf/tcp/4012/ws/p2p/QmVPNwwBtUC3fPTSSsVAgS1WMz1RbEzkDbDxU9BvatXWXZ",
+  "/dns4/ipfs.bulla.network/tcp/4012/wss/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w"
 ]

--- a/mainnet.json
+++ b/mainnet.json
@@ -17,5 +17,5 @@
   "/dns4/ceramic-node.figment.io/tcp/4012/ws/p2p/QmU7oXbft3fBXahQmoTiu3DaGmdRA2T3jQEUnDZ15NAAtJ",
   "/dns4/mgatsonides.nl/tcp/4012/wss/p2p/Qmbhej3gEsPq1Wuoh5ZizqDpi9neeeotSRS2FoAtjqDqM9",
   "/dns4/ipfs.rabbithole.gg/tcp/4012/wss/p2p/Qmc1e7SGtSFAAfzvD8nyGq9MvWebzsDCtgWD5ndJike4FZ",
-  "/dns4/ceramic.bulla.network/tcs/4012/wss/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w"
+  "/dns4/ceramic.bulla.network/tcp/4012/wss/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w"
 ]

--- a/mainnet.json
+++ b/mainnet.json
@@ -16,5 +16,6 @@
   "/dns4/ceramic-ipfs.welibrary.io/tcp/4012/wss/p2p/QmYmQ487j4sXKu28hG7LVKtwXe8qTxbLsiZxtcjao2uwfn",
   "/dns4/ceramic-node.figment.io/tcp/4012/ws/p2p/QmU7oXbft3fBXahQmoTiu3DaGmdRA2T3jQEUnDZ15NAAtJ",
   "/dns4/mgatsonides.nl/tcp/4012/wss/p2p/Qmbhej3gEsPq1Wuoh5ZizqDpi9neeeotSRS2FoAtjqDqM9",
-  "/dns4/ipfs.rabbithole.gg/tcp/4012/wss/p2p/Qmc1e7SGtSFAAfzvD8nyGq9MvWebzsDCtgWD5ndJike4FZ"
+  "/dns4/ipfs.rabbithole.gg/tcp/4012/wss/p2p/Qmc1e7SGtSFAAfzvD8nyGq9MvWebzsDCtgWD5ndJike4FZ",
+  "/dns4/ceramic.bulla.network/tcs/4012/wss/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w"
 ]

--- a/mainnet.json
+++ b/mainnet.json
@@ -18,5 +18,5 @@
   "/dns4/mgatsonides.nl/tcp/4012/wss/p2p/Qmbhej3gEsPq1Wuoh5ZizqDpi9neeeotSRS2FoAtjqDqM9",
   "/dns4/ipfs.rabbithole.gg/tcp/4012/wss/p2p/Qmc1e7SGtSFAAfzvD8nyGq9MvWebzsDCtgWD5ndJike4FZ",
   "/dns4/ipfs-ceramic-elp-external.ownershiplabs.com/tcp/4012/ws/p2p/QmQHTe4GoBmZ3GfZEfiFDWptFE7ij51QvYsuWGWi5kambc",
-  "/dns4/ceramic.bulla.network/tcp/4012/wss/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w" 
+  "/dns4/ceramic.bulla.network/tcp/4012/wss/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w"
 ]

--- a/mainnet.json
+++ b/mainnet.json
@@ -19,5 +19,5 @@
   "/dns4/ipfs.rabbithole.gg/tcp/4012/wss/p2p/Qmc1e7SGtSFAAfzvD8nyGq9MvWebzsDCtgWD5ndJike4FZ",
   "/dns4/ipfs-ceramic-elp-external.ownershiplabs.com/tcp/4012/ws/p2p/QmQHTe4GoBmZ3GfZEfiFDWptFE7ij51QvYsuWGWi5kambc",
   "/dns4/ipfs.metagame.wtf/tcp/4012/ws/p2p/QmVPNwwBtUC3fPTSSsVAgS1WMz1RbEzkDbDxU9BvatXWXZ",
-  "/dns4/ipfs.bulla.network/tcp/4012/wss/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w" 
+  "/dns4/ipfs.bulla.network/tcp/4012/ws/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w"
 ]

--- a/mainnet.json
+++ b/mainnet.json
@@ -18,5 +18,5 @@
   "/dns4/mgatsonides.nl/tcp/4012/wss/p2p/Qmbhej3gEsPq1Wuoh5ZizqDpi9neeeotSRS2FoAtjqDqM9",
   "/dns4/ipfs.rabbithole.gg/tcp/4012/wss/p2p/Qmc1e7SGtSFAAfzvD8nyGq9MvWebzsDCtgWD5ndJike4FZ",
   "/dns4/ipfs-ceramic-elp-external.ownershiplabs.com/tcp/4012/ws/p2p/QmQHTe4GoBmZ3GfZEfiFDWptFE7ij51QvYsuWGWi5kambc",
-  "/dns4/ceramic.bulla.network/tcp/4012/wss/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w"
+  "/dns4/ceramic.bulla.network/tcp/4012/wss/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w" 
 ]


### PR DESCRIPTION
## Team:
Bulla Network
My discord handle is bengobeil#0300

## Use case:
We are using Ceramic to store contacts on our invoicing protocol. Assigning name and email address to a wallet address.

## Overview:
We are running the Ceramic node in AWS using the terraform module. IPFS out of process

We are using s3 buckets for persistence.

Here is my peerId from AWS logs:

![image](https://user-images.githubusercontent.com/64225318/144878427-4dfbff28-2977-4a1c-87ef-dbaf7b9bdc62.png)

Here is my Route 53 record:

![image](https://user-images.githubusercontent.com/64225318/144878559-bf1c7c68-b678-406c-bb95-6fe2adfa6e1d.png)
