### PR TITLE
add Lit protocol to mainnet node list

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -19,5 +19,6 @@
   "/dns4/ipfs.rabbithole.gg/tcp/4012/wss/p2p/Qmb9vwxDsaCu3jcvSvpYh3L4LGii6u2Ptoh6GqnjstoCdF",
   "/dns4/ipfs-ceramic-elp-external.ownershiplabs.com/tcp/4012/ws/p2p/QmQHTe4GoBmZ3GfZEfiFDWptFE7ij51QvYsuWGWi5kambc",
   "/dns4/ipfs.metagame.wtf/tcp/4012/ws/p2p/QmVPNwwBtUC3fPTSSsVAgS1WMz1RbEzkDbDxU9BvatXWXZ",
-  "/dns4/ipfs.bulla.network/tcp/4012/ws/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w"
+  "/dns4/ipfs.bulla.network/tcp/4012/ws/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w",
+  "/dns4/ceramic.litgateway.com/tcp/4012/ws/p2p/QmcGqpNsbf5hQ4iZxL5nAPPffiMRUfcxet5wzpGArQPybV"
 ]


### PR DESCRIPTION
# Team:

Lit Protocol

# Use case:

We've built an access control protocol that can be used to store encrypted data on Ceramic.  Users can easily set who is allowed to decrypt the content based on on-chain access control conditions, like if the user is a member of a DAO or the holder of an NFT.

# Overview:
We run our ceramic daemon with ipfs in-process. We use an intel OVH box with 32gb ram.

# Multiaddress persistence:

Our multiaddress is set to a domain name that maps to a static IP address: /dns4/ceramic.litgateway.com/tcp/4012/ws/p2p/QmcGqpNsbf5hQ4iZxL5nAPPffiMRUfcxet5wzpGArQPybV

# Ceramic State and IPFS Store persistence:

We back up the .ceramic folder nightly to an offsite backup.  The IPFS store is also inside that folder.

# Static IP:

51.222.108.215 and ceramic.litgateway.com