### PR TITLE
Add MetaCred node to testnet-clay peerlist

### DIFF
--- a/testnet-clay.json
+++ b/testnet-clay.json
@@ -3,5 +3,6 @@
   "/dns4/ipfs-ceramic-public-clay-external.ceramic.network/tcp/4012/wss/p2p/QmSqeKpCYW89XrHHxtEQEWXmznp6o336jzwvdodbrGeLTk",
   "/dns4/ipfs-ceramic-private-clay-external.3boxlabs.com/tcp/4012/wss/p2p/QmQotCKxiMWt935TyCBFTN23jaivxwrZ3uD58wNxeg5npi",
   "/dns4/ipfs-ceramic-private-cas-clay-external.3boxlabs.com/tcp/4012/wss/p2p/QmbeBTzSccH8xYottaYeyVX8QsKyox1ExfRx7T1iBqRyCd",
-  "/dns4/ipfs-clay-1.ceramic.geoweb.network/tcp/4012/ws/p2p/QmbDGaByZoomn3NQQjZzwaPWH6ei3ptzWK7a7ECtS35DKL"
+  "/dns4/ipfs-clay-1.ceramic.geoweb.network/tcp/4012/ws/p2p/QmbDGaByZoomn3NQQjZzwaPWH6ei3ptzWK7a7ECtS35DKL",
+  "/dns4/ipfs.md.wtf/tcp/4012/ws/p2p/QmcpD7aNok6Ug3Mqws9kor9pXSBtVUJYiBXmzBnMHNEwcD"
 ]


### PR DESCRIPTION
### Team:
MetaCred

### Use case:
Storing documents for metacred graph + user profiles

### Overview:
Running in my home datacenter across 3 physical machines with Docker-compose and IPFS out of process.

*Multiaddress persistence:*
Docker containers running in a VM, persistent volumes configured with replication and failover across 3 nodes + daily backups to a separate storage array.

*Ceramic State Store persistence:*
Same as above, persistent volumes with replication and backups.

*IPFS Repo persistence:*
Same as above, persistent volumes with replication and backups.

*Static IP:*
Containers exposed to public internet using [Cloudflare Tunnel](https://www.cloudflare.com/products/tunnel/), so IP resolves to 104.21.5.168 right now.