### PR TITLE
feat(clay): add Fayre multiaddress

### DIFF
--- a/testnet-clay.json
+++ b/testnet-clay.json
@@ -4,5 +4,6 @@
   "/dns4/ipfs-ceramic-private-clay-external.3boxlabs.com/tcp/4012/wss/p2p/QmQotCKxiMWt935TyCBFTN23jaivxwrZ3uD58wNxeg5npi",
   "/dns4/ipfs-ceramic-private-cas-clay-external.3boxlabs.com/tcp/4012/wss/p2p/QmbeBTzSccH8xYottaYeyVX8QsKyox1ExfRx7T1iBqRyCd",
   "/dns4/ipfs-clay-1.ceramic.geoweb.network/tcp/4012/ws/p2p/QmbDGaByZoomn3NQQjZzwaPWH6ei3ptzWK7a7ECtS35DKL",
-  "/ip4/209.250.224.39/tcp/4011/p2p/QmahYokVGMAAQzKkSCA3GiiHQT2PEqkBvRHoyYJuff9Ega"
+  "/ip4/209.250.224.39/tcp/4011/p2p/QmahYokVGMAAQzKkSCA3GiiHQT2PEqkBvRHoyYJuff9Ega",
+  "/dns4/ipfs-ceramic-public-clay-external.fayre.com/tcp/4012/wss/p2p/QmTQmSuinoEFAsJUw1mBTy5kW9pexgvMLrPKeGbbkkAk6z"
 ]


### PR DESCRIPTION
This is a new EC2 instance, testing connection to the clay testnet. 

The ingress wss port 4012 is exposed on an AWS ALB, so the IP address can change. However our egress IP is `18.119.7.104`, and will persist as it's an EIP.

Although the ipfs and ceramic services appear to be running correctly, and are seen as healthy by the ALB, it is not clear how I can _test_ the access to the multiaddress. So any help here would be appreciated.

Many thanks. My Discord user is MikeC#0271