### PR TITLE
feat(mainnet): add Fayre multiaddress

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -21,5 +21,6 @@
   "/dns4/ipfs.metagame.wtf/tcp/4012/ws/p2p/QmVPNwwBtUC3fPTSSsVAgS1WMz1RbEzkDbDxU9BvatXWXZ",
   "/dns4/ipfs.bulla.network/tcp/4012/ws/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w",
   "/dns4/ceramic.litgateway.com/tcp/4012/ws/p2p/QmcGqpNsbf5hQ4iZxL5nAPPffiMRUfcxet5wzpGArQPybV",
-  "/dns4/ceramic-ipfs.minds.io/tcp/4012/ws/p2p/Qme6iSNx51Kt34wiRfagt24C3BJSkyqhJSKNrk6QUsPkvJ"
+  "/dns4/ceramic-ipfs.minds.io/tcp/4012/ws/p2p/Qme6iSNx51Kt34wiRfagt24C3BJSkyqhJSKNrk6QUsPkvJ",
+  "/dns4/ipfs-ceramic-public-mainnet-external.fayre.com/tcp/4012/wss/p2p/QmRGLie2fXVjys7B3eiySgRBtPRFHRzrAyes6H9AZ7DhQA"
 ]


### PR DESCRIPTION
### Team:

Fayre
Discord: MikeC#0271

### Overview:

We run Amazon EC2 instances, behind ALBs. Currently running ipfs-daemon@1.2.11 out-of process.

*Multiaddress persistence:*

Each server mounts a persistent ELB which gets snapshotted hourly, and backed-up remotely daily.

*Ceramic State Store persistence:*

As above.

*IPFS Repo persistence:*

As above.

*Static IP:*

Our egress IP is `18.119.7.104`