### PR TITLE
feat(clay): add CVoxel multiaddress 

### DIFF
--- a/testnet-clay.json
+++ b/testnet-clay.json
@@ -7,5 +7,6 @@
   "/ip4/209.250.224.39/tcp/4011/p2p/QmahYokVGMAAQzKkSCA3GiiHQT2PEqkBvRHoyYJuff9Ega",
   "/dns4/ipfs-ceramic-public-clay-external.fayre.com/tcp/4012/wss/p2p/QmTQmSuinoEFAsJUw1mBTy5kW9pexgvMLrPKeGbbkkAk6z",
   "/dns4/ceramic1.senga.io/tcp/4013/wss/p2p/QmSr31iu4tn4tRG6E9zbwj7cV5rWCDjVdPjhA3qpk7N84Z",
-  "/ip4/104.197.185.218/tcp/4012/ws/p2p/QmTp279zxjV2MenrVJ7EbM68PL3sCuLbB3ZKiro9Ej6y8Y"
+  "/ip4/104.197.185.218/tcp/4012/ws/p2p/QmTp279zxjV2MenrVJ7EbM68PL3sCuLbB3ZKiro9Ej6y8Y",
+  "/dns4/ipfs-ceramic-cvoxels-1-1-external.cvoxelceramic.com/tcp/4012/wss/p2p/QmRzZoNhVL9yJwP9HsqLvMGoAMT1xAJgc1US4WDZhs6dHW"
 ]


### PR DESCRIPTION
### Team
C-Voxel

*Submitter Discord handle:*
0xKantaro | C-Voxel#4407

### Use case
We Store the user's CVoxel data on Ceramic Network.
The CVoxel is the user's online work history (part of Verifiable Credentials) generated by the user's on-chain transaction hash, the work details related to the transaction, and the user's signature.

### Overview
We are running the Ceramic node in AWS using the terraform module. IPFS out of process.
Also, We are using s3 buckets for persistence.

*IPFS Multiaddress:*
/dns4/ipfs-ceramic-cvoxels-1-1-external.cvoxelceramic.com/tcp/4012/wss/p2p/QmRzZoNhVL9yJwP9HsqLvMGoAMT1xAJgc1US4WDZhs6dHW

*IPFS Multiaddress persistence:*
Storage in S3 bucket

*Ceramic State Store persistence:*
Storage in S3 bucket

*IPFS Repo persistence:*
Storage in S3 bucket

*Static IP:*
node.cvoxelceramic.com
