### PR TITLE
Add node

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -22,5 +22,6 @@
   "/dns4/ipfs.bulla.network/tcp/4012/ws/p2p/QmZEBCCTLLgcRhWi2D9cH77HGNXKoA2QpXKhrRvJnH4Y4w",
   "/dns4/ceramic.litgateway.com/tcp/4012/ws/p2p/QmcGqpNsbf5hQ4iZxL5nAPPffiMRUfcxet5wzpGArQPybV",
   "/dns4/ceramic-ipfs.minds.io/tcp/4012/ws/p2p/Qme6iSNx51Kt34wiRfagt24C3BJSkyqhJSKNrk6QUsPkvJ",
-  "/dns4/ipfs-ceramic-public-mainnet-external.fayre.com/tcp/4012/wss/p2p/QmRGLie2fXVjys7B3eiySgRBtPRFHRzrAyes6H9AZ7DhQA"
+  "/dns4/ipfs-ceramic-public-mainnet-external.fayre.com/tcp/4012/wss/p2p/QmRGLie2fXVjys7B3eiySgRBtPRFHRzrAyes6H9AZ7DhQA",
+  "/dns4/ceramic-ipfs.viaheadline.xyz/tcp/4012/wss/p2p/QmbBV2YZH1zPo3oCgUnBd9eSt4MjCrbNM7QhcHScuJH9QC"
 ]


### PR DESCRIPTION
Team:

Unlock & Raid Guild

Use case:

We have built a web3 newsletter service using Ceramic as the data storage layer.

Overview:

We run ipfs out of process in a kubernetes cluster as a stateful set.

Our multiaddress is set to a domain name that maps to a static IP address: /dns4/ceramic-ipfs.viaheadline.xyz/tcp/4012/wss/p2p/QmbBV2YZH1zPo3oCgUnBd9eSt4MjCrbNM7QhcHScuJH9QC

Ceramic State and IPFS Store persistence:

We take a snapshot of the ipfs volume periodically

Static IP:

Does this need to be a static egress ip? Our cluster node ips are
- 134.209.162.183
- 134.209.170.202
- 134.209.162.97

